### PR TITLE
Release 0.1.9 (versionCode 10)

### DIFF
--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    id("com.android.application") version "8.5.2" apply false
+    id("com.android.application") version "8.6.1" apply false
     id("org.jetbrains.kotlin.android") version "1.9.25" apply false
     id("com.google.devtools.ksp") version "1.9.25-1.0.20" apply false
     id("com.google.gms.google-services") version "4.4.2" apply false

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -8,7 +8,7 @@ android.nonTransitiveRClass=true
 
 # App version — bump here for releases (tracked in git; CI uses this file as-is).
 # Put real Map keys in android/local.properties (MAPS_API_KEY_DEBUG / MAPS_API_KEY_RELEASE from setup-secrets), or legacy MAPS_API_KEY in env — keep placeholders only here.
-outreach.versionCode=9
-outreach.versionName=0.1.8
+outreach.versionCode=10
+outreach.versionName=0.1.9
 
 MAPS_API_KEY=your_maps_key_here


### PR DESCRIPTION
Bump outreach.versionName and versionCode for the Play release. Upgrade Android Gradle Plugin to 8.6.1.